### PR TITLE
Round to 0 if negative div payout

### DIFF
--- a/MetrICX-UI/src/app/tokens/tokens.page.html
+++ b/MetrICX-UI/src/app/tokens/tokens.page.html
@@ -50,7 +50,7 @@
                     </ion-col>
                     <ion-col *ngIf="token.value.IsSelected" class="amount-value ion-text-end">
                       {{token.value.Balance | number : '1.2-2'}}
-                      <div *ngIf="token.value.Token == 'TAP'" class="divs">Todays expected divs: <span style="color: #b9efa4; font-weight: bold">{{icxDivs | number : '1.2-2'}} <small>ICX (+WW)</small> </span> </div>
+                      <div *ngIf="token.value.Token == 'TAP'" class="divs">Todays expected divs: <span style="color: #b9efa4; font-weight: bold">{{icxDivs | number : '1.2-2'}} <small>ICX (+Wager War)</small> </span> </div>
                     </ion-col>
                 </ion-row>
               </ion-card-content> 

--- a/MetrICX-UI/src/app/tokens/tokens.page.ts
+++ b/MetrICX-UI/src/app/tokens/tokens.page.ts
@@ -52,6 +52,9 @@ export class TokensPage {
              const getTotalTap = await this.iconContract.getTokenBalance('cxc0b5b52c9f8b4251a47e91dda3bd61e5512cd782','cx3b9955d507ace8ac27080ed64948e89783a62ab1')
              const balanceTap = (500000000) - getTotalTap;
              this.icxDivs = (0.8) * excess * (this._tokens[key].Balance / balanceTap);
+             if( this.icxDivs < 0) {
+               this.icxDivs = 0;
+             }
           }
         }
         else{

--- a/MetrICX-UI/src/app/tokens/tokens.page.ts
+++ b/MetrICX-UI/src/app/tokens/tokens.page.ts
@@ -16,6 +16,7 @@ export class TokensPage {
   public address: string;
   public _tokens: TokenSet;
   public icxDivs: number;
+  private TotalTap: number = 500000000;
 
   @Input("addresssetting")
   set addresssetting(value: Address) {
@@ -49,10 +50,10 @@ export class TokensPage {
           this.tokenCount++;
           if(key == 'TAP') {
              const excess = await this.iconContract.GetTapDividends();
-             const getTotalTap = await this.iconContract.getTokenBalance('cxc0b5b52c9f8b4251a47e91dda3bd61e5512cd782','cx3b9955d507ace8ac27080ed64948e89783a62ab1')
-             const balanceTap = (500000000) - getTotalTap;
+             const getTotalTapReleased= await this.iconContract.getTokenBalance('cxc0b5b52c9f8b4251a47e91dda3bd61e5512cd782','cx3b9955d507ace8ac27080ed64948e89783a62ab1')
+             const balanceTap = this.TotalTap - getTotalTapReleased;
              this.icxDivs = (0.8) * excess * (this._tokens[key].Balance / balanceTap);
-             if( this.icxDivs < 0) {
+             if(this.icxDivs < 0) {
                this.icxDivs = 0;
              }
           }


### PR DESCRIPTION
cant have negative ICX payout. If expect divs is below 0 the result should be 0 (no ICX divs)